### PR TITLE
Update trigger branches in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "1.20.1", "1.20.1-development" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "1.20.1", "1.20.1-development" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
The trigger branches for both `push` and `pull_request` events in the testing workflow were updated. They were changed from `main` branch to `1.20.1` and `1.20.1-development` branches.